### PR TITLE
fix: correct printing of input-object and enum default values

### DIFF
--- a/src/build-graph-api/of-introspection/utils.ts
+++ b/src/build-graph-api/of-introspection/utils.ts
@@ -1,4 +1,5 @@
 import type { IntrospectionInputValue, IntrospectionInterfaceType, IntrospectionObjectType } from "graphql";
+import { parseValue, valueFromASTUntyped } from "graphql";
 import { ComponentsKind, INTROSPECTION_COMPONENT_TO_GRAPHAPI_COMPONENT_MAP } from "./declarations";
 
 export function createRef(kind: ComponentsKind, name: string): string {
@@ -10,17 +11,14 @@ export function isIntrospectionInterfaceType(
   return objectType.kind === 'INTERFACE'
 }
 
-export function getDefaultValue(arg: IntrospectionInputValue) {
-  if (!arg.defaultValue || !("name" in arg.type)) {
-    return arg.defaultValue
+export function getDefaultValue(arg: IntrospectionInputValue): unknown {
+  // Introspection stores `defaultValue` as the printed SDL literal string. Parse it into a coerced
+  // JS value (input-object → object, enum/string → string, Int/Float → number, list → array, ...),
+  // matching the of-schema representation so the printer can render defaults type-aware.
+  if (typeof arg.defaultValue !== 'string') { return undefined }
+  try {
+    return valueFromASTUntyped(parseValue(arg.defaultValue))
+  } catch {
+    return undefined
   }
-  switch (arg.type.name) {
-    case 'Int':
-    case 'Float':
-      return +arg.defaultValue
-
-    case 'Boolean':
-      return arg.defaultValue === "true"
-  }
-  return arg.defaultValue
 }

--- a/src/print-graph-api/declarations.ts
+++ b/src/print-graph-api/declarations.ts
@@ -1,3 +1,5 @@
+import { GraphApiComponents } from "../types"
+
 export const BUILT_IN_SCALARS = ["Int", "Float", "Boolean", "String", "ID"] as const
 
 export const GRAPH_API_COMPONENT_KINDS =
@@ -13,6 +15,6 @@ export const GRAPH_API_COMPONENT_KINDS =
 
 export const GRAPH_API_DEFAULT_INDENT = '  '
 
-export type TypePrinter<T = any> = (name: string, type: T) => string
+export type TypePrinter<T = any> = (name: string, type: T, components?: GraphApiComponents) => string
 
 export type Maybe<T> = null | undefined | T

--- a/src/print-graph-api/definition-parts.printer.ts
+++ b/src/print-graph-api/definition-parts.printer.ts
@@ -1,7 +1,8 @@
-import { GraphApiArgs, GraphApiArgument, GraphApiDirective, GraphApiInputObjectDefinition, GraphApiObjectDefinition, GraphApiObjectKind, GraphApiOperation, GraphApiRef } from "../types"
+import { GraphApiAnyDefinition, GraphApiArgs, GraphApiArgument, GraphApiComponents, GraphApiDirective, GraphApiInputObjectDefinition, GraphApiInputUsage, GraphApiObjectDefinition, GraphApiObjectKind, GraphApiOperation, GraphApiRef } from "../types"
 import { printString } from "./atomics.printer"
 import { printBlock, printDescription, printOriginalType, typeName } from "./atomics.printer"
 import { GRAPH_API_DEFAULT_INDENT } from "./declarations"
+import { isGraphApiListDefinition, isGraphApiRef, isObject } from "../guards"
 
 export function printImplementedInterfaces(interfaces: GraphApiRef[] = []): string {
   return interfaces.length
@@ -9,48 +10,94 @@ export function printImplementedInterfaces(interfaces: GraphApiRef[] = []): stri
     : ''
 }
 
-function formatDefaultValue(defaultValue: any): string | undefined {
-  let printedDefault = defaultValue
-  if (printedDefault !== undefined) {
-    if (typeof printedDefault === 'string') {
-      printedDefault = `"${printedDefault}"`
-    } else if (Array.isArray(printedDefault)) {
-      printedDefault = `[${printedDefault.map(item =>
-        typeof item === 'string' ? `"${item}"` : String(item)
-      ).join(', ')}]`
-    } else {
-      printedDefault = String(printedDefault)
-    }
+const printObjectLiteral = (fields: string[]): string => `{${fields.join(', ')}}`
+const printListLiteral = (items: string[]): string => `[${items.join(', ')}]`
+
+// Prints a JS value as a GraphQL literal: strings quoted, numbers/booleans/null bare, lists and
+// objects printed recursively. Without type information enum values print quoted, like strings.
+export function printValueLiteral(value: unknown): string {
+  if (value === null) { return 'null' }
+  if (typeof value === 'string') { return printString(value) }
+  if (typeof value === 'number' || typeof value === 'boolean') { return String(value) }
+  if (Array.isArray(value)) {
+    return printListLiteral(value.map(printValueLiteral))
   }
-  return printedDefault
+  if (isObject(value)) {
+    return printObjectLiteral(Object.entries(value)
+      .map(([name, fieldValue]) => `${name}: ${printValueLiteral(fieldValue)}`))
+  }
+  return String(value)
 }
 
-export function printFields(object: GraphApiObjectDefinition<GraphApiObjectKind>): string {
-  const fieldList: [string, GraphApiOperation][] = Object.entries(object.type.methods ?? {})
+// Prints a value as a GraphQL literal, staying type-aware via its `typeDef` (`$ref`s resolved
+// through `components`):
+//   enum          → unquoted           (e.g. ASC)
+//   input-object  → { field: value }   (each field recursed with its own type)
+//   list          → [ item, ... ]      (each item recursed with its own type)
+//   other/unknown → printValueLiteral  (structural literal)
+function printTypedValue(
+  value: unknown,
+  typeDef: GraphApiRef | GraphApiAnyDefinition | undefined,
+  components: GraphApiComponents,
+): string {
+  if (value === null) { return 'null' }
 
-  const printedDefault = formatDefaultValue('default' in object ? object.default : undefined)
+  // A `$ref` (`#/components/<section>/<name>`) names an enum or input-object component.
+  if (isGraphApiRef(typeDef)) {
+    const [, , section, name] = typeDef.$ref!.split('/')
+    if (section === 'enums' && typeof value === 'string') {
+      return value
+    }
+    if (section === 'inputObjects' && isObject(value) && !Array.isArray(value)) {
+      const properties = components.inputObjects?.[name]?.type.properties ?? {}
+      return printObjectLiteral(Object.entries(value).map(([field, fieldValue]) =>
+        `${field}: ${printTypedValue(fieldValue, properties[field]?.typeDef, components)}`))
+    }
+  }
+
+  // A list type is inline (`type.kind === 'list'`) — recurse with the item type.
+  if (isGraphApiListDefinition(typeDef) && Array.isArray(value)) {
+    const itemTypeDef = typeDef.type.items?.typeDef
+    return printListLiteral(value.map(item => printTypedValue(item, itemTypeDef, components)))
+  }
+
+  return printValueLiteral(value)
+}
+
+// Returns the printable GraphQL literal for a usage's default value, or `undefined` if it has none.
+function resolveDefault(usage: GraphApiInputUsage, components: GraphApiComponents): string | undefined {
+  if (usage.default === undefined) { return undefined }
+  return printTypedValue(usage.default, usage.typeDef, components)
+}
+
+export function printFields(
+  object: GraphApiObjectDefinition<GraphApiObjectKind>,
+  components: GraphApiComponents = {}
+): string {
+  const fieldList: [string, GraphApiOperation][] = Object.entries(object.type.methods ?? {})
 
   const fields = fieldList.map(([name, field], i) => {
     return (
       printDescription(field.description, GRAPH_API_DEFAULT_INDENT, !i) +
       GRAPH_API_DEFAULT_INDENT +
       name +
-      printArgsDefinition(field.args, GRAPH_API_DEFAULT_INDENT) +
+      printArgsDefinition(field.args, GRAPH_API_DEFAULT_INDENT, components) +
       ': ' +
       printOriginalType(field.output.typeDef, field.output.nullable === undefined) +
-      (printedDefault !== undefined ? ` = ${printedDefault}` : '') +
       printUsedDirectives(field.directives)
     )
   })
   return printBlock(fields)
 }
 
-export function printInputFields(object: GraphApiInputObjectDefinition): string {
+export function printInputFields(
+  object: GraphApiInputObjectDefinition,
+  components: GraphApiComponents = {}
+): string {
   const fieldList: [string, GraphApiArgument][] = Object.entries(object.type.properties ?? {})
 
-  const printedDefault = formatDefaultValue('default' in object ? object.default : undefined)
-
   const fields = fieldList.map(([name, field], i) => {
+    const printedDefault = resolveDefault(field, components)
     return (
       printDescription(field.description, GRAPH_API_DEFAULT_INDENT, i === 0) +
       GRAPH_API_DEFAULT_INDENT +
@@ -64,7 +111,11 @@ export function printInputFields(object: GraphApiInputObjectDefinition): string 
   return printBlock(fields)
 }
 
-export function printArgsDefinition(args?: GraphApiArgs, indentation = ''): string {
+export function printArgsDefinition(
+  args?: GraphApiArgs,
+  indentation = '',
+  components: GraphApiComponents = {}
+): string {
   if (!args) { return '' }
 
   const argList = Object.entries(args ?? {})
@@ -76,7 +127,7 @@ export function printArgsDefinition(args?: GraphApiArgs, indentation = ''): stri
 
   if (isSingleLineArgs) {
     return '(' + argList
-      .map(([name, arg]) => printArgDefinition(name, arg))
+      .map(([name, arg]) => printArgDefinition(name, arg, '', true, components))
       .filter(arg => arg !== undefined)
       .join(', ') + ')'
   }
@@ -86,7 +137,7 @@ export function printArgsDefinition(args?: GraphApiArgs, indentation = ''): stri
       .map(([name, arg], i) => {
         const indent = GRAPH_API_DEFAULT_INDENT + indentation
         const first = i === 0
-        return printArgDefinition(name, arg, indent, first)
+        return printArgDefinition(name, arg, indent, first, components)
       })
       .join('\n') + '\n' + indentation + ')'
   )
@@ -96,9 +147,10 @@ export function printArgDefinition(
   name: string,
   arg: GraphApiArgument,
   indent: string = '',
-  first: boolean = true
+  first: boolean = true,
+  components: GraphApiComponents = {}
 ): string {
-  const printedDefault = formatDefaultValue('default' in arg ? arg.default : undefined)
+  const printedDefault = resolveDefault(arg, components)
 
   return (
     printDescription(arg.description, indent, first) +
@@ -117,10 +169,8 @@ export function printUsedDirectiveArgs(argsMeta: Record<string, any> = {}) {
   return '(' + argList.map(([name, value]) => `${name}: ${printProvidedArgValue(value)}`).join(', ') + ')'
 }
 
-export function printProvidedArgValue(value: any) {
-  if (value === undefined) { return '' }
-  if (typeof value === 'string') { return printString(value) }
-  return String(value)
+export function printProvidedArgValue(value: unknown): string {
+  return value === undefined ? '' : printValueLiteral(value)
 }
 
 export function printUsedDirectives(directives?: Record<string, GraphApiDirective>): string {

--- a/src/print-graph-api/definitions.printer.ts
+++ b/src/print-graph-api/definitions.printer.ts
@@ -1,11 +1,15 @@
 import { GRAPH_API_NODE_KIND_OBJECT, GRAPH_API_NODE_KIND_INTERFACE, BUILT_IN_DIRECTIVES_SET } from "../constants"
-import { GraphApiDirectiveDefinition, GraphApiScalarDefinition, GraphApiObjectDefinition, GraphApiUnionDefinition, GraphApiEnumDefinition, GraphApiInputObjectDefinition } from "../types"
+import { GraphApiComponents, GraphApiDirectiveDefinition, GraphApiScalarDefinition, GraphApiObjectDefinition, GraphApiUnionDefinition, GraphApiEnumDefinition, GraphApiInputObjectDefinition } from "../types"
 import { printDescription, typeName, printBlock } from "./atomics.printer"
 import { BUILT_IN_SCALARS, GRAPH_API_DEFAULT_INDENT } from "./declarations"
 import { printArgsDefinition, printUsedDirectives, printImplementedInterfaces, printFields, printInputFields } from "./definition-parts.printer"
 import { OVERRIDDEN_BUILT_IN_DIRECTIVES } from "../build-graph-api/of-schema/declarations"
 
-export function printDirectiveDefinition(name: string, directive: GraphApiDirectiveDefinition): string {
+export function printDirectiveDefinition(
+  name: string,
+  directive: GraphApiDirectiveDefinition,
+  components: GraphApiComponents = {}
+): string {
   // Don't print built-in directives unless they're overridden
   if (BUILT_IN_DIRECTIVES_SET.has(name) && !OVERRIDDEN_BUILT_IN_DIRECTIVES.has(name)) {
     return ""
@@ -15,7 +19,7 @@ export function printDirectiveDefinition(name: string, directive: GraphApiDirect
     printDescription(directive.description) +
     'directive @' +
     name +
-    printArgsDefinition(directive.args) +
+    printArgsDefinition(directive.args, '', components) +
     (directive.repeatable ? ' repeatable' : '') +
     ' on ' +
     directive.locations.join(' | ')
@@ -32,23 +36,31 @@ export function printScalar(name: string, type: GraphApiScalarDefinition): strin
   )
 }
 
-export function printObject(name: string, type: GraphApiObjectDefinition<typeof GRAPH_API_NODE_KIND_OBJECT>): string {
+export function printObject(
+  name: string,
+  type: GraphApiObjectDefinition<typeof GRAPH_API_NODE_KIND_OBJECT>,
+  components: GraphApiComponents = {}
+): string {
   return (
     printDescription(type.description) +
     `type ${name}` +
     printUsedDirectives(type.directives) +
     printImplementedInterfaces(type.type.interfaces) +
-    printFields(type)
+    printFields(type, components)
   )
 }
 
-export function printInterface(name: string, type: GraphApiObjectDefinition<typeof GRAPH_API_NODE_KIND_INTERFACE>): string {
+export function printInterface(
+  name: string,
+  type: GraphApiObjectDefinition<typeof GRAPH_API_NODE_KIND_INTERFACE>,
+  components: GraphApiComponents = {}
+): string {
   return (
     printDescription(type.description) +
     `interface ${name}` +
     printUsedDirectives(type.directives) +
     printImplementedInterfaces(type.type.interfaces) +
-    printFields(type)
+    printFields(type, components)
   )
 }
 
@@ -81,11 +93,15 @@ export function printEnum(name: string, type: GraphApiEnumDefinition): string {
   )
 }
 
-export function printInputObject(name: string, type: GraphApiInputObjectDefinition): string {
+export function printInputObject(
+  name: string,
+  type: GraphApiInputObjectDefinition,
+  components: GraphApiComponents = {}
+): string {
   return (
     printDescription(type.description) +
     `input ${name}` +
     printUsedDirectives(type.directives) +
-    printInputFields(type)
+    printInputFields(type, components)
   )
 }

--- a/src/print-graph-api/index.ts
+++ b/src/print-graph-api/index.ts
@@ -1,8 +1,8 @@
 import { GraphApiSchema } from "../types";
 import { printOperations, printSchemaDefinition, printTypeDefinitions } from "./root-level.printer";
-import { 
+import {
   GRAPH_QL_MUTATION_TYPE_NAME_DEFAULT,
-  GRAPH_QL_QUERY_TYPE_NAME_DEFAULT,  
+  GRAPH_QL_QUERY_TYPE_NAME_DEFAULT,
   GRAPH_QL_SUBSCRIPTION_TYPE_NAME_DEFAULT
 } from "../constants";
 
@@ -12,11 +12,13 @@ export function printGraphApi(graphapi: GraphApiSchema): string {
   const mutationTypeName = graphapi.mutationTypeName || GRAPH_QL_MUTATION_TYPE_NAME_DEFAULT
   const subscriptionTypeName = graphapi.subscriptionTypeName || GRAPH_QL_SUBSCRIPTION_TYPE_NAME_DEFAULT
 
+  // `components` is threaded into the printers so default values can be printed type-aware
+  const { components } = graphapi
   return [
     printSchemaDefinition(graphapi),
-    ...printTypeDefinitions(graphapi.components),
-    printOperations(queryTypeName, graphapi.queries),
-    printOperations(mutationTypeName, graphapi.mutations),
-    printOperations(subscriptionTypeName, graphapi.subscriptions),
+    ...printTypeDefinitions(components),
+    printOperations(queryTypeName, graphapi.queries, components),
+    printOperations(mutationTypeName, graphapi.mutations, components),
+    printOperations(subscriptionTypeName, graphapi.subscriptions, components),
   ].filter(Boolean).join('\n\n')
 }

--- a/src/print-graph-api/root-level.printer.ts
+++ b/src/print-graph-api/root-level.printer.ts
@@ -45,7 +45,8 @@ export function printSchemaDefinition(schema: GraphApiSchema): Maybe<string> {
 
 export function printOperations(
   name: string,
-  operations?: GraphApiObjectDefinition<GraphApiObjectKind>['type']['methods']
+  operations?: GraphApiObjectDefinition<GraphApiObjectKind>['type']['methods'],
+  components: GraphApiComponents = {}
 ): string {
   if (!operations) { return "" }
   return printObject(name, {
@@ -54,7 +55,7 @@ export function printOperations(
       kind: GRAPH_API_NODE_KIND_OBJECT,
       methods: operations,
     },
-  })
+  }, components)
 }
 
 export function printTypeDefinitions(components: GraphApiComponents = {}): string[] {
@@ -67,7 +68,9 @@ export function printTypeDefinitions(components: GraphApiComponents = {}): strin
     if (!definitions) { continue }
 
     for (const [name, definition] of Object.entries(definitions)) {
-      const printed = printType(name, definition)
+      // `components` is passed so type-aware default printing can resolve `$ref`s; printers that
+      // have no default values (scalar, union, enum) simply ignore it.
+      const printed = printType(name, definition, components)
       if (printed) {
         printedTypes.push(printed)
       }

--- a/test/printGraphApi.bugs.test.ts
+++ b/test/printGraphApi.bugs.test.ts
@@ -1,5 +1,5 @@
 import { printGraphApi } from "../src/print-graph-api"
-import { buildGraphApi } from "./helpers/build-graphApi"
+import { buildGraphApi, GRAPH_API_BUILD_MODE_INTROSPECTION, GRAPH_API_BUILD_MODE_SCHEMA } from "./helpers/build-graphApi"
 
 describe('bugs in printing GraphAPI', () => {
   it('directive "specifiedBy" is not duplicated when other directives are present', () => {
@@ -28,6 +28,100 @@ scalar Money`
     // Verify the generated GraphQL contains properly formatted quotes
     expect(actual).toContain('`"100.57"`')
     expect(actual).toContain('scalar Money')
+  })
+
+  it('should print an input-object default value without throwing and round-trip it', () => {
+    const original = `input Point {
+      x: Int
+      y: Int
+    }
+    
+    type Query {
+      near(p: Point = {x: 1, y: 2}): String
+    }`
+    const graphApi = buildGraphApi(original)
+
+    expect(() => printGraphApi(graphApi)).not.toThrow()
+    const actual = printGraphApi(graphApi)
+    expect(actual).toContain('p: Point = {x: 1, y: 2}')
+    expect(() => buildGraphApi(actual)).not.toThrow()
+  })
+
+  // Enum defaults lose the enum-vs-string distinction once coerced; the printer re-derives the type
+  // from the schema components so enum values print unquoted (`ASC`, not `"ASC"`). Verified for both
+  // build paths: of-schema stores a coerced value, of-introspection parses the literal string.
+  it.each([GRAPH_API_BUILD_MODE_SCHEMA, GRAPH_API_BUILD_MODE_INTROSPECTION] as const)(
+    'should print enum default values unquoted (top-level and nested), built from %s',
+    (mode) => {
+      const original = `enum OrderDirection {
+        ASC
+        DESC
+      }
+      
+      input RepositoryOrder {
+        field: String
+        direction: OrderDirection
+      }
+      
+      type Query {
+        repositories(orderBy: RepositoryOrder = {field: "NAME", direction: ASC}, direction: OrderDirection = DESC): String
+      }`
+      const actual = printGraphApi(buildGraphApi(original, mode))
+
+      expect(actual).toContain('orderBy: RepositoryOrder = {field: "NAME", direction: ASC}')
+      expect(actual).toContain('direction: OrderDirection = DESC')
+      expect(() => buildGraphApi(actual)).not.toThrow()
+    }
+  )
+
+  it('should coerce scalar, wrapped and list default values from introspection instead of leaving literal strings', () => {
+    const original = `type Query {
+  search(count: Int = 42, rate: Float = 3.14, flag: Boolean = true, req: Int! = 7, tags: [String!] = ["a", "b"], nums: [Int!] = [1, 2]): String
+}`
+    const actual = printGraphApi(buildGraphApi(original, GRAPH_API_BUILD_MODE_INTROSPECTION))
+
+    expect(actual).toBe(original)
+  })
+
+  it('should print input-object field defaults for every kind (scalar, enum, list, nested-object, list-of-list)', () => {
+    const original = `enum Role {
+  ADMIN
+  USER
+}
+
+input Inner {
+  role: Role
+}
+
+input Outer {
+  inner: Inner
+}
+
+input Filter {
+  id: Int
+  role: Role
+}
+
+input User {
+  name: String = "any"
+  limit: Int = 10
+  role: Role = ADMIN
+  names: [String!] = ["a", "b"]
+  roles: [Role!] = [ADMIN, USER]
+  filter: Filter = {id: 5, role: ADMIN}
+  nested: Outer = {inner: {role: ADMIN}}
+  matrix: [[Filter]] = [[{id: 1, role: USER}]]
+}
+
+type Query {
+  create(user: User): String
+}`
+    const actual = printGraphApi(buildGraphApi(original))
+
+    // The schema is already in canonical printed form, so the dump must reproduce it verbatim.
+    // One exact match pins every default kind at once — scalar, enum, list, nested-object and
+    // list-of-list — plus field order and formatting, which `toContain` can't catch.
+    expect(actual).toBe(original)
   })
 
   it('directive arguments with special characters should print correctly', () => {

--- a/test/unit-tests/printInputValue.test.ts
+++ b/test/unit-tests/printInputValue.test.ts
@@ -1,5 +1,5 @@
 import { DirectiveLocation } from 'graphql'
-import { printArgDefinition } from '../../src/print-graph-api/definition-parts.printer'
+import { printArgDefinition, printValueLiteral } from '../../src/print-graph-api/definition-parts.printer'
 
 describe('printInputValue', () => {
   it('simple arg', () => {
@@ -192,12 +192,12 @@ describe('printInputValue', () => {
 
     it('array with number values default', () => {
       const actual = printArgDefinition('numbers', {
-        typeDef: { 
+        typeDef: {
           type: {
             kind: 'list',
-            items: { 
+            items: {
               typeDef: { type: { kind: 'integer' } },
-              nullable: false 
+              nullable: false
             }
           }
         } as any, // Using 'as any' for test simplicity
@@ -205,6 +205,31 @@ describe('printInputValue', () => {
       })
       const expected = 'numbers: [Int!] = [1, 2, 3]'
       expect(actual).toBe(expected)
-    })        
+    })
+  })
+})
+
+describe('printValueLiteral (default / input-object value literals)', () => {
+  it('should print scalars with string quoted and number/boolean/null bare', () => {
+    expect(printValueLiteral('x')).toBe('"x"')
+    expect(printValueLiteral(42)).toBe('42')
+    expect(printValueLiteral(true)).toBe('true')
+    expect(printValueLiteral(null)).toBe('null')
+  })
+
+  it('should print a null-prototype input-object value without throwing', () => {
+    // graphql-js coerces input-object default values into null-prototype objects
+    const nullProto = Object.assign(Object.create(null), { field: 'NAME', direction: 'ASC' })
+    expect(() => printValueLiteral(nullProto)).not.toThrow()
+    expect(printValueLiteral(nullProto)).toBe('{field: "NAME", direction: "ASC"}')
+  })
+
+  it('should print a plain input-object value with mixed scalar fields', () => {
+    expect(printValueLiteral({ x: 1, y: true, z: 'a' })).toBe('{x: 1, y: true, z: "a"}')
+  })
+
+  it('should print nested objects, arrays and null', () => {
+    expect(printValueLiteral({ list: [{ id: '1' }, { id: '2' }], n: null }))
+      .toBe('{list: [{id: "1"}, {id: "2"}], n: null}')
   })
 })


### PR DESCRIPTION
## Fix printing of input-object and enum default values

### Problem

Publishing a GraphQL schema whose arguments/input fields have **input-object default values** — e.g. GitHub's public schema with `orderBy: RepositoryOrder = {field: NAME, direction: ASC}` — failed while serializing the schema back to SDL:

```
TypeError: Cannot convert object to primitive value
```

The schema itself is valid; the crash was purely in the printer (`printGraphApi`).

### Root cause

`graphql-js` coerces input-object default values into **null-prototype objects** (`Object.create(null)`, no `toString`). The old `formatDefaultValue` fell back to `String(value)` for non-string/array values, which throws on such objects.

A second, quieter issue: coerced values lose the enum-vs-string distinction (enum `ASC` and string `"ASC"` are both stored as the JS string `"ASC"`), so a value-only printer cannot render enum defaults unquoted — it needs the **type**. This matters because api-processor round-trips the printed SDL (`document-group` / crop paths re-parse it), where a quoted enum default silently degrades into a string.

### Behavioral / release notes

- Input-object field defaults now appear in the printed SDL (were silently omitted before).
- of-introspection default values are now coerced (consistent with of-schema); this also drops a spurious `default: null` for arguments without a default. Expect a one-time formatting/hash change for the introspection path on adoption.
